### PR TITLE
Remove 'key' from required fields

### DIFF
--- a/elements/snippets/googleMap.php
+++ b/elements/snippets/googleMap.php
@@ -56,7 +56,7 @@ if(empty($settings['key'])){
 }
 
 //we now have a setings array populated
-$required = array('key', 'address');
+$required = array('address');
 foreach ($required as $key => $value) {
 	if(!isset($settings[$value]) || is_null($settings[$value]) || $settings[$value] == ''){
 		return "googleMap Error: Missing Required Option: ".$value;


### PR DESCRIPTION
The requirement of 'key' was leading to a failure while the Google call continues to work without it. Suggest removing it from required list.